### PR TITLE
Fix knight number placement

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -60,14 +60,20 @@ export const Game = {
                         }
                     }
                     if (value === 'N') {
-                        if (Number.isInteger(data[(y - 2) * 8 + (x - 1)])) data[(y - 2) * 8 + (x - 1)]++;
-                        if (Number.isInteger(data[(y - 2) * 8 + (x + 1)])) data[(y - 2) * 8 + (x + 1)]++;
-                        if (Number.isInteger(data[(y + 2) * 8 + (x - 1)])) data[(y + 2) * 8 + (x - 1)]++;
-                        if (Number.isInteger(data[(y + 2) * 8 + (x + 1)])) data[(y + 2) * 8 + (x + 1)]++;
-                        if (Number.isInteger(data[(y - 1) * 8 + (x - 2)])) data[(y - 1) * 8 + (x - 2)]++;
-                        if (Number.isInteger(data[(y - 1) * 8 + (x + 2)])) data[(y - 1) * 8 + (x + 2)]++;
-                        if (Number.isInteger(data[(y + 1) * 8 + (x - 2)])) data[(y + 1) * 8 + (x - 2)]++;
-                        if (Number.isInteger(data[(y + 1) * 8 + (x + 2)])) data[(y + 1) * 8 + (x + 2)]++;
+                        const positions = [
+                            [x - 1, y - 2],
+                            [x - 1, y + 2],
+                            [x + 1, y - 2],
+                            [x + 1, y + 2],
+                            [x - 2, y - 1],
+                            [x - 2, y + 1],
+                            [x + 2, y - 1],
+                            [x + 2, y + 1],
+                        ];
+                        for (const [x, y] of positions) {
+                            if (x < 0 || x >= 8 || y < 0 || y >= 8) continue;
+                            if (Number.isInteger(data[y * 8 + x])) data[y * 8 + x]++;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
There was no bounds check on the knight setup code, which meant that knights near the board edge were causing tiles to be incorrectly marked. This can be seen in the top right tile of this game:
<img width="502" alt="hmm" src="https://user-images.githubusercontent.com/27852915/201563368-9b049b2a-0ecf-4d27-b32b-c6539fe48f7f.png">

I've added this bounds check, as well as slightly reducing the repetition in the relevant code.