### PR TITLE
fix tests double running in ci

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,13 +17,12 @@ jobs:
         with:
           node-version: 18
       - run: npm install
-      - run: npm test
+      - run: npm run coverage
       - run: npm run build
       - uses: actions/upload-artifact@v2
         with:
           name: Chessweeper
           path: ./build
-      - run: npm run coverage
       - name: Upload coverage to Codacy
         uses: codacy/codacy-coverage-reporter-action@master
         with:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview",
     "build": "tsc && vite build",
     "test": "vitest",
-    "coverage": "vitest run --coverage",
+    "coverage": "vitest --coverage",
     "format": "npx prettier --write .",
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx",
     "tsc": "tsc --noEmit"


### PR DESCRIPTION
could maybe have better npm script names (any suggestions?), but npm run coverage already runs tests as well as generates coverage. I still want to keep separate non-coverage-generating npm script locally tho