### PR TITLE
fix negative pieces number css

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -94,6 +94,7 @@ hr {
   border-style: inset;
   padding: 10px 0;
   margin: 0;
+  line-height: 30px;
 }
 
 #board-report {


### PR DESCRIPTION
Didn't notice this before but css was messed up when pieces remaining value went negative

Before:
<img width="321" alt="image" src="https://user-images.githubusercontent.com/16028371/206544578-3a93336a-71e7-4b0f-83f4-a9401b93893e.png">

After:
<img width="322" alt="image" src="https://user-images.githubusercontent.com/16028371/206544675-b72def70-0df9-456a-9c90-5af387cbd9c8.png">
