### PR TITLE
cleanup

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           node-version: 18
       - run: npm install
+      - run: npm run lint
       - run: npm run coverage
       - run: npm run build
       - uses: actions/upload-artifact@v2

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 build
 coverage
+package-lock.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 build
 coverage
 package-lock.json
+.github/ISSUE_TEMPLATE

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Chessweeper &middot; [![Discord](https://img.shields.io/badge/discord-join-7289DA.svg?logo=discord&longCache=true&style=flat)](https://discord.gg/VjJ95N2mV9)
+# Chessweeper &middot; [![Discord](https://img.shields.io/badge/discord-join-7289DA.svg?logo=discord&longCache=true&style=flat)](https://discord.gg/VjJ95N2mV9) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/522c0c888197458d80afef9ff5955371)](https://www.codacy.com/gh/Chessweeper/Chessweeper/dashboard?utm_source=github.com&utm_medium=referral&utm_content=Chessweeper/Chessweeper&utm_campaign=Badge_Grade) [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/522c0c888197458d80afef9ff5955371)](https://www.codacy.com/gh/Chessweeper/Chessweeper/dashboard?utm_source=github.com&utm_medium=referral&utm_content=Chessweeper/Chessweeper&utm_campaign=Badge_Coverage)
 
 Chess X Minesweeper - Numbered tiles represent the number of pieces that have that tile in check.
 

--- a/README.md
+++ b/README.md
@@ -16,17 +16,16 @@ To build a release version of the game, run `npm run build`. The output is place
 
 ### All NPM Commands
 
-| Command    | Description                                                                            |
-| ---------- | -------------------------------------------------------------------------------------- |
-| `start`    | run dev server                                                                         |
-| `preview`  | run output from local build directory (requires running build first)                   |
-| `build`    | create production build in the `build` directory                                       |
-| `test`     | run unit tests                                                                         |
-| `coverage` | run unit tests and generate a coverage report                                          |
-| `format`   | run prettier formatting on all files (husky does this on staged files before a commit) |
-| `lint`     | check for eslint warnings/errors in all ts/tsx files                                   |
-| `tsc`      | run typescript compiler to check for type errors in all ts/tsx files                   |
-| `prepare`  | automatically run by NPM during install to setup husky                                 |
+| Command    | Description                                                          |
+| ---------- | -------------------------------------------------------------------- |
+| `start`    | run dev server                                                       |
+| `preview`  | run output from local build directory (requires running build first) |
+| `build`    | create production build in the `build` directory                     |
+| `test`     | run unit tests                                                       |
+| `coverage` | run unit tests and generate a coverage report                        |
+| `lint`     | check for eslint warnings/errors in all ts/tsx files                 |
+| `tsc`      | run typescript compiler to check for type errors in all ts/tsx files |
+| `prepare`  | automatically run by NPM during install to setup husky               |
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To build a release version of the game, run `npm run build`. The output is place
 | `test`     | run unit tests                                                                         |
 | `coverage` | run unit tests and generate a coverage report                                          |
 | `format`   | run prettier formatting on all files (husky does this on staged files before a commit) |
-| `lint`     | check for eslint warnings/errors in all files                                          |
+| `lint`     | check for eslint warnings/errors in all ts/tsx files                                   |
 | `tsc`      | run typescript compiler to check for type errors in all ts/tsx files                   |
 | `prepare`  | automatically run by NPM during install to setup husky                                 |
 

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "build": "tsc && vite build",
     "test": "vitest",
     "coverage": "vitest run --coverage",
-    "format": "npx prettier --write .",
-    "lint": "eslint . --ext .ts,.tsx,.js,.jsx",
+    "format": "prettier --write .",
+    "lint": "eslint .",
     "tsc": "tsc --noEmit",
     "prepare": "husky install"
   },
@@ -60,8 +60,11 @@
     "vitest": "^0.25.5"
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx}": [
+    "*.{ts,tsx}": [
       "eslint --cache --fix",
+      "prettier --write"
+    ],
+    "*.{md,css,yml,json}": [
       "prettier --write"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "build": "tsc && vite build",
     "test": "vitest",
     "coverage": "vitest run --coverage",
-    "format": "prettier --write .",
     "lint": "eslint .",
     "tsc": "tsc --noEmit",
     "prepare": "husky install"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,4 @@
 {
-  "type": "module",
-  "name": "chessweeper",
-  "version": "1.0.0",
-  "description": "Chess X Minesweeper",
   "engines": {
     "node": ">=18.0.0"
   },
@@ -17,17 +13,6 @@
     "prepare": "husky install"
   },
   "browserslist": "defaults and supports async-functions",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/Xwilarg/Chessweeper.git"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/Xwilarg/Chessweeper/issues"
-  },
-  "homepage": "https://github.com/Xwilarg/Chessweeper#readme",
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.1",
     "boardgame.io": "^0.50.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,6 @@
     "removeComments": true,
     "noUnusedLocals": true
   },
-  "include": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"], // todo: remove js/jsx when all converted
+  "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["./build"]
 }


### PR DESCRIPTION
- Improve lint-staged by running prettier on more file types on commit
- Added codacy badges to README, they are mapped to master branch though. Develop branches could be added too but didn't want to overdo it
- Prettier ignore ISSUE_TEMPLATES and also ignored them in Codacy because the .md files were throwing a lot of errors
- Add lint check to CI
- Removed format command from package.json because prettier --write overwrites every file it runs on
- Removed bloat from package.json because it the package won't be published
- Other cleanup